### PR TITLE
Allow full url paths

### DIFF
--- a/lib/soundcloud.js
+++ b/lib/soundcloud.js
@@ -175,7 +175,7 @@ module.exports = (function() {
     }
     callback = callback || function () {};
 
-    if ( path && path.indexOf('/') === 0 ) {
+    if ( valid(path) ) {
 
       params.client_id = this.clientId;
       params.format = 'json';
@@ -245,6 +245,11 @@ module.exports = (function() {
     }
 
     return req.end();
+  }
+
+  // filters path endpoints to known formats
+  function valid( path ){
+    return path && ( path.indexOf('/') === 0 || path.indexOf('http') === 0 );
   }
 
   /* ====================================================== */

--- a/lib/soundcloud.js
+++ b/lib/soundcloud.js
@@ -167,16 +167,16 @@ module.exports = (function() {
 
   SoundCloud.prototype.makeCall = function(method, path, userParams, callback) {
     var params;
+    if ( !callback || typeof callback !== 'function' ) {
+      callback = userParams; // callback must be the third parameter
+      params = {};
+    } else {
+      params = userParams;
+    }
+    callback = callback || function () {};
 
     if ( path && path.indexOf('/') === 0 ) {
-      if ( !callback || typeof callback !== 'function' ) {
-        callback = userParams; // callback must be the third parameter
-        params = {};
-      } else {
-        params = userParams;
-      }
 
-      callback = callback || function () {};
       params.client_id = this.clientId;
       params.format = 'json';
 


### PR DESCRIPTION
I wanted to play a stream of a Soundcloud file, and I have to authenticate the URL against the app's creds, as mentioned here:
https://developers.soundcloud.com/docs/api/guide#streaming

I've made a separate function for validating paths, in case this logic needs to be extended/refined in the future. 
