### PR TITLE
Add outh_token to /me endpoints

### DIFF
--- a/lib/soundcloud.js
+++ b/lib/soundcloud.js
@@ -179,6 +179,10 @@ module.exports = (function() {
 
       params.client_id = this.clientId;
       params.format = 'json';
+      
+      if ( this.isAuthorized ) {
+        params.oauth_token = this.accessToken;
+      }
 
       return request({
         method: method,

--- a/lib/soundcloud.js
+++ b/lib/soundcloud.js
@@ -179,9 +179,18 @@ module.exports = (function() {
 
       params.client_id = this.clientId;
       params.format = 'json';
-      
-      if ( this.isAuthorized ) {
-        params.oauth_token = this.accessToken;
+
+      var endpoint = path.split('/')[1];
+      if ( endpoint === 'me' ) {
+        if ( this.isAuthorized ) {
+          params.oauth_token = this.accessToken;  
+        } else {
+          callback({
+            message: 'Not authorized to use path: ' + path
+          });
+          
+          return false;
+        }
       }
 
       return request({


### PR DESCRIPTION
The [/me](https://developers.soundcloud.com/docs/api/reference#me) endpoint for the SoundCloud API requires the the oauth_token passed with the query string. Without it calls to the API return 401 Unauthorized
