### PR TITLE
modify soundcloud track id in README.md & change https to follow-directs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ SC.init({
 Once authorized (or if you're accessing unprotected endpoints), you may now make calls to the SoundCloud API [documented here](https://developers.soundcloud.com/docs/api/reference). An example could be as follows:
 
 ```javascript
-SC.get('/tracks/164497989', function(err, track) {
+SC.get('/tracks/276882056', function(err, track) {
   if ( err ) {
     throw err;
   } else {

--- a/lib/soundcloud.js
+++ b/lib/soundcloud.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var https       = require('https');
+var https       = require('follow-redirects').https;
 var qs          = require('querystring');
 var hostApi     = 'api.soundcloud.com';
 var hostConnect = 'https://soundcloud.com/connect';

--- a/package.json
+++ b/package.json
@@ -17,5 +17,6 @@
     "node": ">=0.10.26"
   },
   "dependencies": {
+    "follow-redirects": "^0.2.0"
   }
 }


### PR DESCRIPTION
hello

First, Previous track id in README.md is not working.

Second, /resolve (soundcloud api) function returns this value.
track retrieved: { status: '302 - Found',
  location: 'https://api.soundcloud.com/playlists/11569777.json?client_id=my_client_id' }

I want to get the value playlist by resolve function.
So I changed https to follow-directs this is redirect automatically module.

review, please.

Thanks for your useful library.
